### PR TITLE
Merge v0.0.4 release into master and add check for archived repositories

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at phildini@phildini.net. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+0.0.4 (2017-11-12)
+------------------
+
+* Add "update" command
+* Add ability to set key in environment variable
+* Rework interface
+
 0.0.3 (2017-06-11)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Epithet
      :alt: Updates
 
 
-Manage your labels.
+`Manage your labels`_.
 
 
 * Free software: MIT license
@@ -35,6 +35,7 @@ Credits
 
 This package was created with Cookiecutter_ and the `audreyr/cookiecutter-pypackage`_ project template.
 
+.. _`Manage your labels`: https://www.wordfugue.com/introducing-epithet/
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 .. _`audreyr/cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -7,7 +7,7 @@ improved!
 
 You can use the epithet commands without a key, but you might quickly run into
 rate limiting issues. Get a personal token from Github_ and pass it into the
-``--key`` option to solve this.
+``--key`` option, or set the ``EPITHET_KEY`` environment variable to solve this.
 
 To use Epithet in a project::
 
@@ -16,22 +16,60 @@ To use Epithet in a project::
     Usage: epithet [OPTIONS] COMMAND [ARGS]...
 
     Options:
-      --dryrun  Don't actually change or create labels
-      --help    Show this message and exit.
+      --key TEXT  Github OAuth Token
+      --dryrun    Don't actually change or create labels
+      --url TEXT  API URL - change if GitHub Enterprise
+      --help      Show this message and exit.
 
     Commands:
       add
+      delete
       list
 
     $ epithet add --help
+
     Usage: epithet add [OPTIONS]
 
     Options:
-      --name TEXT   Name of new label
-      --color TEXT  Color of new label
-      --key TEXT    OAuth Token
-      --org TEXT    Organization to get repos from
-      --repo TEXT   Optionally select a single repo
-      --help        Show this message and exit.
+      -l, --label       Add label
+      -m, --milestone   Add milestone
+      -o, --org TEXT    Organization
+      -r, --repo TEXT   Optionally select a single repo
+      -n, --name TEXT   Name of new label
+      -c, --color TEXT  Color of new label
+      --help            Show this message and exit.
+
+    $ epithet list --help
+    Usage: epithet list [OPTIONS]
+
+    Options:
+      -l, --label      List labels
+      -m, --milestone  List milestones
+      -o, --org TEXT   Organization to get repos from
+      -r, --repo TEXT  Optionally select a single repo
+      --help           Show this message and exit.
+
+    $ epithet delete --help
+    Usage: epithet delete [OPTIONS]
+
+    Options:
+      -l, --label      Delete label
+      -m, --milestone  Delete milestones
+      -o, --org TEXT   Organization
+      -r, --repo TEXT  Optionally select a single repo
+      -n, --name TEXT  Name of label or milestone to delete
+      --help           Show this message and exit.
+
+    $ epithet update --help
+    Usage: epithet update [OPTIONS]
+
+    Options:
+      -l, --label      Update label
+      -m, --milestone  Update milestone
+      -o, --org TEXT   Organization
+      -r, --repo TEXT  Optionally select a single repo
+      -n, --name TEXT  Name of the existing label
+      --new-name TEXT  New name of the label
+      --help           Show this message and exit.
 
 .. _Github: https://github.com/settings/tokens

--- a/epithet/__init__.py
+++ b/epithet/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Philip James"""
 __email__ = 'phildini@phildini.net'
-__version__ = '0.0.3'
+__version__ = '0.0.5'

--- a/epithet/epithet.py
+++ b/epithet/epithet.py
@@ -75,16 +75,18 @@ def add(ctx, label, milestone, org, repo, name, color):
         click.echo(" * Checking {}".format(repo.name))
         if label:
             click.echo("Adding a label with name: {} and  color: {}".format(name, color))
-            labels = {}
-            for label in repo.get_labels():
-                labels[label.name] = label
-            if name in labels:
+            labels = {label.name: label for label in repo.get_labels()}
+            if name.lower() in [l.lower() for l in labels.keys()]:
                 click.echo(
                     " - Found {} on {} (Dryrun: {})".format(
-                        labels[name].name, repo.name, ctx.obj['dryrun']
+                        name, repo.name, ctx.obj['dryrun']
                     )
                 )
-                if labels[name].color != color and not ctx.obj['dryrun'] \
+                if name not in labels.keys():
+                    for labelname, label in labels.items():
+                        if labelname.lower() == name.lower():
+                            labels[labelname].edit(name=name, color=color)
+                elif labels[name].color != color and not ctx.obj['dryrun'] \
                    and not repo.archived:
                     labels[name].edit(name=name, color=color)
             else:
@@ -97,13 +99,12 @@ def add(ctx, label, milestone, org, repo, name, color):
                     repo.create_label(name=name, color=color)
         if milestone:
             click.echo("Adding a milestone with name: {}".format(name))
-            milestones = {}
-            for milestone in repo.get_milestones():
-                milestones[milestone.title] = milestone
-            if name in milestones:
+            milestones = {milestone.title: milestone
+                          for milestone in repo.get_milestones()}
+            if name.lower() in [m.lower() for m in milestones.keys()]:
                 click.echo(
                     " - Found {} on {} (Dryrun: {})".format(
-                        milestones[name].name, repo.name, ctx.obj['dryrun']
+                        name, repo.name, ctx.obj['dryrun']
                     )
                 )
             else:

--- a/epithet/epithet.py
+++ b/epithet/epithet.py
@@ -84,7 +84,8 @@ def add(ctx, label, milestone, org, repo, name, color):
                         labels[name].name, repo.name, ctx.obj['dryrun']
                     )
                 )
-                if labels[name].color != color and not ctx.obj['dryrun']:
+                if labels[name].color != color and not ctx.obj['dryrun'] \
+                   and not repo.archived:
                     labels[name].edit(name=name, color=color)
             else:
                 click.echo(
@@ -92,7 +93,7 @@ def add(ctx, label, milestone, org, repo, name, color):
                         name, repo.name, ctx.obj['dryrun']
                     )
                 )
-                if not ctx.obj['dryrun']:
+                if not ctx.obj['dryrun'] and not repo.archived:
                     repo.create_label(name=name, color=color)
         if milestone:
             click.echo("Adding a milestone with name: {}".format(name))
@@ -111,7 +112,7 @@ def add(ctx, label, milestone, org, repo, name, color):
                         name, repo.name, ctx.obj['dryrun']
                     )
                 )
-                if not ctx.obj['dryrun']:
+                if not ctx.obj['dryrun'] and not repo.archived:
                     repo.create_milestone(title=name)
 
 

--- a/epithet/epithet.py
+++ b/epithet/epithet.py
@@ -26,24 +26,25 @@ def get_repos(key, org, repo, url):
 
 
 @click.group()
+@click.option('--key', envvar='EPITHET_KEY', help="Github OAuth Token")
 @click.option('--dryrun', is_flag=True, help="Don't actually change or create labels")
 @click.option('--url', help="API URL - change if GitHub Enterprise")
 @click.pass_context
-def cli(ctx, dryrun, url):
-    ctx.obj['dryrun'] = dryrun
-    ctx.obj['url'] = url
-
-
-@cli.command()
-@click.option('--key', help="OAuth Token")
-@click.option('--org', help="Organization to get repos from")
-@click.option('--repo', help="Optionally select a single repo")
-@click.pass_context
-def list(ctx, key, org, repo):
+def cli(ctx, key, dryrun, url):
     if not key:
         click.echo("You must provide a GitHub API v3 key")
         return
-    for repo in get_repos(key, org, repo, ctx.obj['url']):
+    ctx.obj['dryrun'] = dryrun
+    ctx.obj['url'] = url
+    ctx.obj['key'] = key
+
+
+@cli.command()
+@click.option('--org', help="Organization to get repos from")
+@click.option('--repo', help="Optionally select a single repo")
+@click.pass_context
+def list(ctx, org, repo):
+    for repo in get_repos(ctx.obj['key'], org, repo, ctx.obj['url']):
         click.echo("\n * {}:\n".format(repo.name))
         for label in repo.get_labels():
             click.echo(" - {} ({})".format(label.name, label.color))
@@ -53,16 +54,12 @@ def list(ctx, key, org, repo):
 @cli.command()
 @click.option('--name', help="Name of new label")
 @click.option('--color', help="Color of new label")
-@click.option('--key', help="OAuth Token")
 @click.option('--org', help="Organization to get repos from")
 @click.option('--repo', help="Optionally select a single repo")
 @click.pass_context
-def add(ctx, name, color, key, org, repo):
-    if not key:
-        click.echo("You must provide a GitHub API v3 key")
-        return
+def add(ctx, name, color, org, repo):
     click.echo("Adding a label with name: {} and  color: {}".format(name, color))
-    for repo in get_repos(key, org, repo, ctx.obj['url']):
+    for repo in get_repos(ctx.obj['key'], org, repo, ctx.obj['url']):
         click.echo(" * Checking {}".format(repo.name))
         labels = {}
         for label in repo.get_labels():
@@ -86,16 +83,12 @@ def add(ctx, name, color, key, org, repo):
 
 @cli.command()
 @click.option('--name', help="Name of label to delete")
-@click.option('--key', help="OAuth Token")
 @click.option('--org', help="Organization to get repos from")
 @click.option('--repo', help="Optionally select a single repo")
 @click.pass_context
-def delete(ctx, name, key, org, repo):
-    if not key:
-        click.echo("You must provide a GitHub API v3 key")
-        return
+def delete(ctx, name, org, repo):
     click.echo("Deleting label: {}".format(name))
-    for repo in get_repos(key, org, repo, ctx.obj['url']):
+    for repo in get_repos(ctx.obj['key'], org, repo, ctx.obj['url']):
         click.echo(" * Checking {}".format(repo.name))
         labels = {}
         for label in repo.get_labels():

--- a/epithet/epithet.py
+++ b/epithet/epithet.py
@@ -40,67 +40,112 @@ def cli(ctx, key, dryrun, url):
 
 
 @cli.command()
-@click.option('--org', help="Organization to get repos from")
-@click.option('--repo', help="Optionally select a single repo")
+@click.option('--label', '-l', is_flag=True, help="List labels", default=False)
+@click.option('--milestone', '-m', is_flag=True, help='List milestones', default=False)
+@click.option('--org', '-o', help="Organization to get repos from")
+@click.option('--repo', '-r', help="Optionally select a single repo")
 @click.pass_context
-def list(ctx, org, repo):
+def list(ctx, label, milestone, org, repo):
     for repo in get_repos(ctx.obj['key'], org, repo, ctx.obj['url']):
         click.echo("\n * {}:\n".format(repo.name))
-        for label in repo.get_labels():
-            click.echo(" - {} ({})".format(label.name, label.color))
+        if label:
+            for label in repo.get_labels():
+                click.echo(" - {} ({})".format(label.name, label.color))
+        if milestone:
+            for milestone in repo.get_milestones():
+                click.echo(" - {} ({})".format(milestone.title))
 
 
 
 @cli.command()
-@click.option('--name', help="Name of new label")
-@click.option('--color', help="Color of new label")
-@click.option('--org', help="Organization to get repos from")
-@click.option('--repo', help="Optionally select a single repo")
+@click.option('--label', '-l', is_flag=True, help="Add label", default=False)
+@click.option('--milestone', '-m', is_flag=True, help='Add milestone', default=False)
+@click.option('--org', '-o', help="Organization")
+@click.option('--repo', '-r', help="Optionally select a single repo")
+@click.option('--name', '-n', help="Name of new label")
+@click.option('--color', '-c', help="Color of new label")
 @click.pass_context
-def add(ctx, name, color, org, repo):
-    click.echo("Adding a label with name: {} and  color: {}".format(name, color))
+def add(ctx, label, milestone, org, repo, name, color):
     for repo in get_repos(ctx.obj['key'], org, repo, ctx.obj['url']):
         click.echo(" * Checking {}".format(repo.name))
-        labels = {}
-        for label in repo.get_labels():
-            labels[label.name] = label
-        if name in labels:
-            click.echo(
-                " - Found {} on {} (Dryrun: {})".format(
-                    labels[name].name, repo.name, ctx.obj['dryrun']
+        if label:
+            click.echo("Adding a label with name: {} and  color: {}".format(name, color))
+            labels = {}
+            for label in repo.get_labels():
+                labels[label.name] = label
+            if name in labels:
+                click.echo(
+                    " - Found {} on {} (Dryrun: {})".format(
+                        labels[name].name, repo.name, ctx.obj['dryrun']
+                    )
                 )
-            )
-            if labels[name].color != color and not ctx.obj['dryrun']:
-                labels[name].edit(name=name, color=color)
-        else:
-            click.echo(
-                " - Creating {} on {} (Dryrun: {})".format(
-                    name, repo.name, ctx.obj['dryrun']
+                if labels[name].color != color and not ctx.obj['dryrun']:
+                    labels[name].edit(name=name, color=color)
+            else:
+                click.echo(
+                    " - Creating {} on {} (Dryrun: {})".format(
+                        name, repo.name, ctx.obj['dryrun']
+                    )
                 )
-            )
-            if not ctx.obj['dryrun']:
-                repo.create_label(name=name, color=color)
+                if not ctx.obj['dryrun']:
+                    repo.create_label(name=name, color=color)
+        if milestone:
+            click.echo("Adding a milestone with name: {}".format(name))
+            milestones = {}
+            for milestone in repo.get_milestones():
+                milestones[milestone.title] = milestone
+            if name in milestones:
+                click.echo(
+                    " - Found {} on {} (Dryrun: {})".format(
+                        milestones[name].name, repo.name, ctx.obj['dryrun']
+                    )
+                )
+            else:
+                click.echo(
+                    " - Creating {} on {} (Dryrun: {})".format(
+                        name, repo.name, ctx.obj['dryrun']
+                    )
+                )
+                if not ctx.obj['dryrun']:
+                    repo.create_milestone(title=name)
+
 
 @cli.command()
-@click.option('--name', help="Name of label to delete")
-@click.option('--org', help="Organization to get repos from")
-@click.option('--repo', help="Optionally select a single repo")
+@click.option('--label', '-l', is_flag=True, help="Delete label", default=False)
+@click.option('--milestone', '-m', is_flag=True, help='Delete milestones', default=False)
+@click.option('--org', '-o', help="Organization")
+@click.option('--repo', '-r', help="Optionally select a single repo")
+@click.option('--name', '-n', help="Name of label or milestone to delete")
 @click.pass_context
-def delete(ctx, name, org, repo):
-    click.echo("Deleting label: {}".format(name))
+def delete(ctx, label, milestone, org, repo, name):
     for repo in get_repos(ctx.obj['key'], org, repo, ctx.obj['url']):
         click.echo(" * Checking {}".format(repo.name))
-        labels = {}
-        for label in repo.get_labels():
-            labels[label.name] = label
-        if name in labels:
-            click.echo(
-                " - Found {} on {}, deleting (Dryrun: {})".format(
-                    labels[name].name, repo.name, ctx.obj['dryrun']
+        if label:
+            click.echo("Deleting label: {}".format(name))
+            labels = {}
+            for label in repo.get_labels():
+                labels[label.name] = label
+            if name in labels:
+                click.echo(
+                    " - Found {} on {}, deleting (Dryrun: {})".format(
+                        labels[name].name, repo.name, ctx.obj['dryrun']
+                    )
                 )
-            )
-            if not ctx.obj['dryrun']:
-                labels[name].delete()
+                if not ctx.obj['dryrun']:
+                    labels[name].delete()
+        if milestone:
+            click.echo("Deleting milestone: {}".format(name))
+            milestones = {}
+            for milestone in repo.get_milestones():
+                milestones[milestone.title] = milestone
+            if name in milestones:
+                click.echo(
+                    " - Found {} on {}, deleting (Dryrun: {})".format(
+                        milestones[name].title, repo.name, ctx.obj['dryrun']
+                    )
+                )
+                if not ctx.obj['dryrun']:
+                    milestones[name].delete()
 
 
 if __name__ == "__main__":

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.3
+current_version = 0.0.4
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ test_requirements = [
 
 setup(
     name='epithet',
-    version='0.0.3',
+    version='0.0.4',
     description="Manage your labels.",
     long_description=readme + '\n\n' + history,
     author="Philip James",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'Click>=6.0',
-    'PyGithub==1.34',
+    'PyGithub==1.43.8',
 ]
 
 test_requirements = [
@@ -20,7 +20,7 @@ test_requirements = [
 
 setup(
     name='epithet',
-    version='0.0.4',
+    version='0.0.5',
     description="Manage your labels.",
     long_description=readme + '\n\n' + history,
     author="Philip James",

--- a/tests/test_epithet.py
+++ b/tests/test_epithet.py
@@ -15,26 +15,15 @@ from contextlib import contextmanager
 from click.testing import CliRunner
 
 from epithet import epithet
-from epithet import cli
-
 
 
 class TestEpithet(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
-    def test_000_something(self):
-        pass
-
     def test_command_line_interface(self):
         runner = CliRunner()
-        result = runner.invoke(cli.main)
+        result = runner.invoke(epithet.cli)
         assert result.exit_code == 0
-        assert 'epithet.cli.main' in result.output
-        help_result = runner.invoke(cli.main, ['--help'])
+        assert 'Usage: cli' in result.output
+        help_result = runner.invoke(epithet.cli, ['--help'])
         assert help_result.exit_code == 0
-        assert '--help  Show this message and exit.' in help_result.output
+        assert 'Show this message and exit.' in help_result.output


### PR DESCRIPTION
The v0.0.4 release was available as a tag, but the changes were not present in the master branch so I rebased the commits into master. In addition, when running the command against an organization, if any of the repositories were archived and didn't have the specified label then the command would raise an exception due to the repo being read only, so I added a check for the archived status to handle that situation.